### PR TITLE
feat: Add Docker support for the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use an official Python runtime as a parent image
+FROM python:3.12-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Install uv
+RUN pip install uv
+
+# Copy the current directory contents into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN uv pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application files
+COPY . .
+
+# Create and declare the output directory as a volume
+RUN mkdir -p /app/output
+VOLUME /app/output
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Run server.py when the container launches
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -85,3 +85,30 @@ Once the server is running, open your web browser and go to:
 [http://localhost:8000](http://localhost:8000)
 
 The web page will automatically list all the `.mp3` files from the `output` directory. You can select a file from the dropdown menu and use the player controls to listen to it.
+
+## Docker Support
+
+You can also run this application inside a Docker container.
+
+### Building the Image
+
+First, build the Docker image:
+
+```bash
+docker build -t tts-app .
+```
+
+### Running the Container
+
+To run the container and mount the `output` directory to your local machine, use the following command:
+
+```bash
+docker run -p 8000:8000 -v "$(pwd)/output":/app/output tts-app
+```
+
+This will:
+- Run the container in the background.
+- Map port 8000 of the container to port 8000 on your local machine.
+- Mount the `output` directory from your current local directory to the `/app/output` directory in the container. This allows you to access the generated audio files on your host machine.
+
+You can then access the web player at [http://localhost:8000](http://localhost:8000).


### PR DESCRIPTION
This commit introduces a `Dockerfile` to containerize the web application.

The `Dockerfile` is configured to:
- Use the `python:3.12-slim` base image.
- Install and use `uv` for Python package management.
- Install dependencies from `requirements.txt`.
- Expose port 8000 for the web server.
- Declare a volume for the `output` directory to persist generated files.

Additionally, this commit updates `README.md` with a new "Docker Support" section, providing clear instructions on how to build and run the Docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added official Docker support to run the app in a container.
  * Exposes port 8000 for easy access to the web interface.
  * Provides a dedicated output directory that can be mounted to the host for persisted results.

* **Documentation**
  * Introduced a Docker deployment guide with steps to build the image, run the container, map port 8000, and mount the output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->